### PR TITLE
fix converting int64(LittleEndian) to float32

### DIFF
--- a/utils/noso.go
+++ b/utils/noso.go
@@ -3,6 +3,6 @@ package utils
 import "fmt"
 
 func ToNoso(n int64) string {
-	var noso = float32(n) / 10e8
+	var noso = float32(n) / 10e7
 	return fmt.Sprintf("%.8f Noso", noso)
 }


### PR DESCRIPTION
Subject: Fix for Incorrect Conversion of int64 (LittleEndian) to float32

Dear @gcarreno ,

I hope this message finds you well.

I wanted to bring to your attention an issue I encountered with the balance conversion of the developer fund: **NpryectdevepmentfundsGE**. Specifically, when converting from `int64 (LittleEndian)` to `float32`, the current implementation is yielding an incorrect result.

Your code currently displays the following data:

```Balance: 8611.471875000 Noso```

However, the correct balance should be:

```Balance: 86114.71875000 Noso```

I believe the problem lies in the conversion logic, and I hope that the fix I’ve proposed in my recent pull request will resolve the issue and provide the correct balance.

Thank you for considering my contribution, and please don't hesitate to reach out if further clarification or adjustments are needed.

Best regards,  
**pasichDev**
