### PR TITLE
Bump to stable pager API

### DIFF
--- a/cmd/block.go
+++ b/cmd/block.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/Friends-Of-Noso/NosoData-Go/legacy"
 	"github.com/Friends-Of-Noso/NosoData-Go/utils"
-	"github.com/alecthomas/chroma/v2/formatters"
-	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
-	"github.com/walles/moar/m"
+	"github.com/walles/moor/v2/pkg/moor"
 )
 
 var (
@@ -76,14 +74,9 @@ func runBlock(cmd *cobra.Command, args []string) {
 func displayBlock(jsonOutput bool) {
 	buf := new(bytes.Buffer)
 
-	options := m.ReaderOptions{}
-
 	if jsonOutput {
-		options.ShouldFormat = true
-		options.Style = styles.Get("native")
 		fmt.Fprintln(buf, block.AsJSON())
 	} else {
-		options.ShouldFormat = false
 		fmt.Fprintln(buf, "Number:           ", block.Number)
 		fmt.Fprintf(buf, "HASH:              '%s'\n", block.HASH)
 		fmt.Fprintln(buf, "Time Start:       ", time.Unix(block.TimeStart, 0))
@@ -142,21 +135,10 @@ func displayBlock(jsonOutput bool) {
 		}
 	}
 
-	reader, err := m.NewReaderFromStream(
-		fmt.Sprintf("Block: %d", block.Number),
-		buf,
-		formatters.TTY,
-		options,
-	)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-
-	pager := m.NewPager(reader)
-	pager.WrapLongLines = true
-
-	err = pager.Page()
+	err := moor.PageFromStream(buf, moor.Options{
+		Title:         fmt.Sprintf("Block: %d", block.Number),
+		WrapLongLines: true,
+	})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)

--- a/cmd/gvts.go
+++ b/cmd/gvts.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/chroma/v2/formatters"
-	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
-	"github.com/walles/moar/m"
+	"github.com/walles/moor/v2/pkg/moor"
 
 	"github.com/Friends-Of-Noso/NosoData-Go/legacy"
 )
@@ -66,14 +64,9 @@ func runGVTS(cmd *cobra.Command, args []string) {
 func displayGVTS(jsonOutput bool) {
 	buf := new(bytes.Buffer)
 
-	options := m.ReaderOptions{}
-
 	if jsonOutput {
-		options.ShouldFormat = true
-		options.Style = styles.Get("native")
 		fmt.Fprintln(buf, gvts.AsJSON())
 	} else {
-		options.ShouldFormat = false
 		for i, e := range gvts.Entries {
 			fmt.Fprintln(buf, "Position:", i)
 			fmt.Fprintf(buf, "    Number:  '%s'\n", e.Number.GetString())
@@ -83,21 +76,10 @@ func displayGVTS(jsonOutput bool) {
 		}
 	}
 
-	reader, err := m.NewReaderFromStream(
-		"GVTS",
-		buf,
-		formatters.TTY,
-		options,
-	)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-
-	pager := m.NewPager(reader)
-	pager.WrapLongLines = true
-
-	err = pager.Page()
+	err := moor.PageFromStream(buf, moor.Options{
+		Title:         "GVTS",
+		WrapLongLines: true,
+	})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)

--- a/cmd/psos.go
+++ b/cmd/psos.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/chroma/v2/formatters"
-	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
-	"github.com/walles/moar/m"
+	"github.com/walles/moor/v2/pkg/moor"
 
 	"github.com/Friends-Of-Noso/NosoData-Go/legacy"
 )
@@ -66,14 +64,9 @@ func runPSOS(cmd *cobra.Command, args []string) {
 func displayPSO(jsonOutput bool) {
 	buf := new(bytes.Buffer)
 
-	options := m.ReaderOptions{}
-
 	if jsonOutput {
-		options.ShouldFormat = true
-		options.Style = styles.Get("native")
 		fmt.Fprintln(buf, pso.AsJSON())
 	} else {
-		options.ShouldFormat = false
 		fmt.Fprintln(buf, "Block:", pso.Block)
 		fmt.Fprintf(buf, "  MN Locks(%d):\n", pso.MNLockCount)
 		for i, mli := range pso.MNLocks {
@@ -84,21 +77,10 @@ func displayPSO(jsonOutput bool) {
 		fmt.Fprintf(buf, "  PSO Count(%d):\n", pso.PSOCount)
 	}
 
-	reader, err := m.NewReaderFromStream(
-		"PSO",
-		buf,
-		formatters.TTY,
-		options,
-	)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-
-	pager := m.NewPager(reader)
-	pager.WrapLongLines = true
-
-	err = pager.Page()
+	err := moor.PageFromStream(buf, moor.Options{
+		Title:         "PSO",
+		WrapLongLines: true,
+	})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/chroma/v2/formatters"
-	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
-	"github.com/walles/moar/m"
+	"github.com/walles/moor/v2/pkg/moor"
 
 	"github.com/Friends-Of-Noso/NosoData-Go/legacy"
 	"github.com/Friends-Of-Noso/NosoData-Go/utils"
@@ -67,14 +65,9 @@ func runSummary(cmd *cobra.Command, args []string) {
 func displaySummary(jsonOutput bool) {
 	buf := new(bytes.Buffer)
 
-	options := m.ReaderOptions{}
-
 	if jsonOutput {
-		options.ShouldFormat = true
-		options.Style = styles.Get("native")
 		fmt.Fprintln(buf, summary.AsJSON())
 	} else {
-		options.ShouldFormat = false
 		for i, a := range summary.Accounts {
 			fmt.Fprintln(buf, "Position:", i)
 			fmt.Fprintf(buf, "    Hash:           '%s'\n", a.Hash.GetString())
@@ -85,21 +78,10 @@ func displaySummary(jsonOutput bool) {
 		}
 	}
 
-	reader, err := m.NewReaderFromStream(
-		"Summary",
-		buf,
-		formatters.TTY,
-		options,
-	)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-
-	pager := m.NewPager(reader)
-	pager.WrapLongLines = true
-
-	err = pager.Page()
+	err := moor.PageFromStream(buf, moor.Options{
+		Title:         "Summary",
+		WrapLongLines: true,
+	})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/chroma/v2/formatters"
-	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
-	"github.com/walles/moar/m"
+	"github.com/walles/moor/v2/pkg/moor"
 
 	"github.com/Friends-Of-Noso/NosoData-Go/legacy"
 	"github.com/Friends-Of-Noso/NosoData-Go/utils"
@@ -67,14 +65,9 @@ func runWallet(cmd *cobra.Command, args []string) {
 func displayWallet(jsonOutput bool) {
 	buf := new(bytes.Buffer)
 
-	options := m.ReaderOptions{}
-
 	if jsonOutput {
-		options.ShouldFormat = true
-		options.Style = styles.Get("native")
 		fmt.Fprintln(buf, wallet.AsJSON())
 	} else {
-		options.ShouldFormat = false
 		for i, a := range wallet.Accounts {
 			fmt.Fprintln(buf, "Position:", i)
 			fmt.Fprintf(buf, "    Hash: '%s'\n", a.Hash.GetString())
@@ -88,21 +81,10 @@ func displayWallet(jsonOutput bool) {
 		}
 	}
 
-	reader, err := m.NewReaderFromStream(
-		"Wallet",
-		buf,
-		formatters.TTY,
-		options,
-	)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
-
-	pager := m.NewPager(reader)
-	pager.WrapLongLines = true
-
-	err = pager.Page()
+	err := moor.PageFromStream(buf, moor.Options{
+		Title:         "Wallet",
+		WrapLongLines: true,
+	})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/Friends-Of-Noso/NosoData-Go
 go 1.24.4
 
 require (
-	github.com/alecthomas/chroma/v2 v2.18.1-0.20250607032210-6ffb4659a458
 	github.com/spf13/cobra v1.9.1
-	github.com/walles/moar v1.32.3
+	github.com/walles/moor/v2 v2.0.3
 	gotest.tools/v3 v3.3.0
 )
 
 require (
+	github.com/alecthomas/chroma/v2 v2.19.1-0.20250723141813-02ff9d482061 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.18.1-0.20250607032210-6ffb4659a458 h1:OsIC6WxSRL920xtk4xTpy4aC5FEZas5Jf+Y8hVlk/OI=
-github.com/alecthomas/chroma/v2 v2.18.1-0.20250607032210-6ffb4659a458/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
-github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
-github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/alecthomas/chroma/v2 v2.19.1-0.20250723141813-02ff9d482061 h1:JPUL3EzyoNO+xKmIATiNB2N9SqrYmo9o9K05jYgtNlI=
+github.com/alecthomas/chroma/v2 v2.19.1-0.20250723141813-02ff9d482061/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
+github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
+github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/walles/moar v1.32.3 h1:Dsp/Q16kjbxvzHi5JBVHTIaWv5TYTBXqwCDYcpI+JHg=
-github.com/walles/moar v1.32.3/go.mod h1:WIqw8HFY18yQhVm+3KYqu1LIszoSFKVHN4lYvfKq8Wk=
+github.com/walles/moor/v2 v2.0.3 h1:By8HiacKOQ4JmInpA2Cv2dz4MBzbyGlVWVyXu1L0K1Q=
+github.com/walles/moor/v2 v2.0.3/go.mod h1:82fVnOL0tbob33ib8GFJEiLTcmU+tpYLU94SFt2/p+s=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
moar was renamed to moor: https://github.com/walles/moor/pull/305

As part of that change, a new stable public API was added.

This change bumps the pager API to moor v2.

I dropped the ShouldFormat setting, because that happens only for JSON input. There should be no visible change.

I also dropped picking the style. That's done automatically based on the terminal background color. For dark terminal backgrounds, "native" is the default, so there should be no visible change.
